### PR TITLE
Virglrenderer fedora34

### DIFF
--- a/Formula/virglrenderer.rb
+++ b/Formula/virglrenderer.rb
@@ -1,7 +1,7 @@
 class Virglrenderer < Formula
   desc "VirGL virtual OpenGL renderer"
   homepage "https://gitlab.freedesktop.org/virgl/virglrenderer"
-  url "https://github.com/freedesktop/virglrenderer.git", using: :git, revision: "d470a2df588d86fca460db889bfe5b2cce7caebb"
+  url "https://gitlab.freedesktop.org/virgl/virglrenderer.git", using: :git, revision: "5e2d10463d6b79080c3376138221b73ea6e95186"
   version "20210404.1"
   license "MIT"
 
@@ -18,8 +18,8 @@ class Virglrenderer < Formula
 
   # waiting for upstreaming of https://github.com/akihikodaki/virglrenderer/tree/macos
   patch :p1 do
-    url "https://raw.githubusercontent.com/knazarov/homebrew-qemu-virgl/a6ce7624ccd762107ad6077972eb6393eaeda78f/Patches/virglrenderer-v02.diff"
-    sha256 "cd6b9c35a27182b1e38078881ec63a0db86be99e151ee5012e7e1c7edad39319"
+    url "https://raw.githubusercontent.com/knazarov/homebrew-qemu-virgl/381fdeb4ffe53196fe308852b3573a7ab2d2a2b9/Patches/virglrenderer-v03.diff"
+    sha256 "45a0c32ed419a3440093efdd26d55810bfd6a4616bdeed9fc62db2fdd0c0a7f6"
   end
 
   def install

--- a/Formula/virglrenderer.rb
+++ b/Formula/virglrenderer.rb
@@ -1,7 +1,7 @@
 class Virglrenderer < Formula
   desc "VirGL virtual OpenGL renderer"
   homepage "https://gitlab.freedesktop.org/virgl/virglrenderer"
-  url "https://gitlab.freedesktop.org/virgl/virglrenderer.git", using: :git, revision: "5e2d10463d6b79080c3376138221b73ea6e95186"
+  url "https://gitlab.freedesktop.org/virgl/virglrenderer.git", revision: "5e2d10463d6b79080c3376138221b73ea6e95186"
   version "20210428.1"
   license "MIT"
 

--- a/Formula/virglrenderer.rb
+++ b/Formula/virglrenderer.rb
@@ -2,7 +2,7 @@ class Virglrenderer < Formula
   desc "VirGL virtual OpenGL renderer"
   homepage "https://gitlab.freedesktop.org/virgl/virglrenderer"
   url "https://gitlab.freedesktop.org/virgl/virglrenderer.git", using: :git, revision: "5e2d10463d6b79080c3376138221b73ea6e95186"
-  version "20210404.1"
+  version "20210428.1"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
This patch adds fixes necessary to run Fedora 34 under qemu without visual glitches