### PR TITLE
Pre-build x86 binaries for big sur

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-latest, macos-11.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
Currently the binary bottles are pre-built only for catalina. We should have big sur as well.