### PR TITLE
Add binary bottles for libangle for arm and x86

### DIFF
--- a/Formula/libangle.rb
+++ b/Formula/libangle.rb
@@ -7,8 +7,9 @@ class Libangle < Formula
 
   bottle do
     root_url "https://github.com/knazarov/homebrew-qemu-virgl/releases/download/libangle-20210315.1"
-    rebuild 1
-    sha256 cellar: :any, catalina: "032ffcba856c6b16b07edc1156100b943dc1322df4e61da8620edbd503957ef9"
+    sha256 cellar: :any, arm64_big_sur: "0e7a61000a6c4e7f8050184c8b92a6c432f612a85e2c72d54c3888f18635fd61"
+    sha256 cellar: :any, big_sur:       "032ffcba856c6b16b07edc1156100b943dc1322df4e61da8620edbd503957ef9"
+    sha256 cellar: :any, catalina:      "032ffcba856c6b16b07edc1156100b943dc1322df4e61da8620edbd503957ef9"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
The builds of libangle are very flaky. So to make the formula more usable, there should be a set of binary bottles for it for latest macos versions. 

Should fix #23 