### PR TITLE
Replace FreeDOS FD12FLOPPY.ZIP link

### DIFF
--- a/Formula/qemu-virgl.rb
+++ b/Formula/qemu-virgl.rb
@@ -33,7 +33,7 @@ class QemuVirgl < Formula
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
   resource "test-image" do
-    url "https://dl.bintray.com/homebrew/mirror/FD12FLOPPY.zip"
+    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip"
     sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
   end
 


### PR DESCRIPTION
The last FreeDOS floppy link doesn't seem to work. Entire website reports "Forbidden!".

The SHA256 here is the same. This solves https://github.com/knazarov/homebrew-qemu-virgl/issues/29

Signed-off-by: June <zanthed@riseup.net>