### PR TITLE
Add a patch to properly detect libusb dependency

### DIFF
--- a/Formula/qemu-virgl.rb
+++ b/Formula/qemu-virgl.rb
@@ -43,6 +43,11 @@ class QemuVirgl < Formula
     sha256 "5301b861cf17486043d212a4385280e0aa6dada9453bbe66c2db47c6299155e7"
   end
 
+  patch :p1 do
+    url "https://raw.githubusercontent.com/knazarov/homebrew-qemu-virgl/18e6df670467c9d2cd2ec18375f4539cd6105028/Patches/qemu-libusb-v01.diff"
+    sha256 "2da15abeb2a8f859e7f2fae359ff5ded72ffa49c8db6bf4d90115fd1f5e01f22"
+  end
+
   def install
     ENV["LIBTOOL"] = "glibtool"
 


### PR DESCRIPTION
During the latest refactoring in qemu master, libusb dependency wasn't tracked correctly. To fix it, a [patch](https://github.com/qemu/qemu/commit/670b35919301213e45ef42ed689f6ea67004d714) was later added, but qemu-virgl is based on a slightly earlier patch, so it didn't include it.

Fixes #38 