### PR TITLE
Replace qemu user networking with vmnet, in README

### DIFF
--- a/Formula/qemu-virgl.rb
+++ b/Formula/qemu-virgl.rb
@@ -29,6 +29,7 @@ class QemuVirgl < Formula
   depends_on "nettle"
   depends_on "pixman"
   depends_on "snappy"
+  depends_on "spice-protocol"
   depends_on "vde"
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
@@ -64,9 +65,11 @@ class QemuVirgl < Formula
       --extra-cflags=-I#{Formula["libangle"].opt_prefix}/include
       --extra-cflags=-I#{Formula["libepoxy-angle"].opt_prefix}/include
       --extra-cflags=-I#{Formula["virglrenderer"].opt_prefix}/include
+      --extra-cflags=-I#{Formula["spice-protocol"].opt_prefix}/include/spice-1
       --extra-ldflags=-L#{Formula["libangle"].opt_prefix}/lib
       --extra-ldflags=-L#{Formula["libepoxy-angle"].opt_prefix}/lib
       --extra-ldflags=-L#{Formula["virglrenderer"].opt_prefix}/lib
+      --extra-ldflags=-L#{Formula["spice-protocol"].opt_prefix}/lib
       --disable-sdl
       --disable-gtk
     ]

--- a/README.md
+++ b/README.md
@@ -142,3 +142,28 @@ qemu-system-x86_64 \
          -netdev user,id=net,ipv6=off \
          -drive "if=virtio,format=raw,file=hdd.raw,discard=on"
 ```
+
+
+## Usage - Advanced
+
+This section has additional configuration you may want to do to improve your workflow
+
+
+### Clipboard sharing
+
+There's now support for sharing clipboard in both directions: from vm->host and host->vm. To enable clibpoard sharing, add this to your command line:
+
+```
+         -chardev qemu-vdagent,id=spice,name=vdagent,clipboard=on \
+         -device virtio-serial-pci \
+         -device virtserialport,chardev=spice,name=com.redhat.spice.0
+```
+
+### Mouse integration
+
+By default, you have mouse pointer capture and have to release mouse pointer from the VM using keyboard shortcut. In order to have seamless mouse configuration,
+add the following to your command line instead of `-device virtio-mouse-pci`:
+
+```
+	-device usb-tablet \
+```

--- a/README.md
+++ b/README.md
@@ -167,3 +167,43 @@ add the following to your command line instead of `-device virtio-mouse-pci`:
 ```
 	-device usb-tablet \
 ```
+
+### MacOS native networking for VMs (vmnet)
+
+akihikodaki's patch set includes support for vmnet which offers more flexibility than `-netdev user`, and allows higher network throughput. (see https://github.com/akihikodaki/qemu/commit/72a35bb6e0a16bb7d346ba822a6d47293915fc95).
+
+For instance, to enable bridge mode, replace:
+
+```
+    -device virtio-net-pci,netdev=net \
+    -netdev user,id=net,ipv6=off \
+```
+
+with
+
+
+```
+    -netdev vmnet-macos,id=n1,mode=bridged,ifname=en0 \
+    -device virtio-net,netdev=n1 \
+```
+
+vmnet also offers "host" and "shared" networking model:
+
+```
+   -netdev vmnet-macos,id=str,mode=host|shared[,dhcp_start_address=addr,dhcp_end_address=addr,dhcp_subnet_mask=mask]
+```
+
+***caveats:***
+
+1) vmnet requires running qemu as root.
+2) current vmnet API (Apple) doesn't support setting MAC address, so it will be randomized every time the VM is started.
+
+To work around 2), for now it's possible to set the MAC address within the VM.
+
+As root, create a file `/etc/udev/rules.d/75-mac-vmnet.rules` with the following content:
+
+```
+ACTION=="add", SUBSYSTEM=="net", KERNEL=="enp0s3", RUN+="/usr/bin/ip link set dev %k address 00:11:22:33:44:55"
+```
+
+replace `enp0s3` with the name of your interface and `00:11:22:33:44:55` with the desired IP.


### PR DESCRIPTION
akihikodaki's patch set includes support for vmnet which offers more
flexibility than `-netdev user` and allows higher network throughput.
(see https://github.com/akihikodaki/qemu/commit/72a35bb6e0a16bb7d346ba822a6d47293915fc95)

I have been experiencing `watchdog: BUG: soft lockup` while using user
networking on M1.  vmnet solved all my problems and allowed me to
bridge the VM with my Mac WiFi interface.

vmnet also offers "host" and "shared" networking model:
   -netdev vmnet-macos,id=str,mode=host|shared