### PR TITLE
Update qemu-virgl.rb

### DIFF
--- a/Formula/qemu-virgl.rb
+++ b/Formula/qemu-virgl.rb
@@ -29,7 +29,7 @@ class QemuVirgl < Formula
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
   resource "test-image" do
-    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip"
+    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/official/FD12FLOPPY.zip"
     sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
   end
 


### PR DESCRIPTION
looks like ibiblio archive changed URL for freedom floppy not so long ago.