### PR TITLE
update FreeDOS 1.2 download url

### DIFF
--- a/Formula/qemu-virgl.rb
+++ b/Formula/qemu-virgl.rb
@@ -29,7 +29,7 @@ class QemuVirgl < Formula
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
   resource "test-image" do
-    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip"
+    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/official/FD12FLOPPY.zip"
     sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
   end
 


### PR DESCRIPTION
currently running `brew install knazarov/qemu-virgl/qemu-virgl` fails with

```
Error: qemu-virgl: Failed to download resource "qemu-virgl--test-image"
Failure while executing; `/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.0.21\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 13.4\)\ curl/7.88.1 --header Accept-Language:\ en --retry 3 --fail --location --silent --head --request GET https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip` exited with 22. Here's the output:
curl: (22) The requested URL returned error: 404
```

It looks like the issue occurs because the `FD12FLOPPY.zip` file was moved. This patch updates the download url accordingly.